### PR TITLE
modified type from u16 to u32

### DIFF
--- a/src/golo.rs
+++ b/src/golo.rs
@@ -126,7 +126,7 @@ impl GoogleLocationHistory {
 /// between interpolated locations, according to the time difference between the given timestamp
 /// the nearest location timestamp. If the half-distance is smaller than both location accuracies,
 /// ignore it and linearly scale between the two accuracies instead.
-fn interpolate_accuracy(timestamp_ms: i64, before: &Location, after: &Location) -> u16 {
+fn interpolate_accuracy(timestamp_ms: i64, before: &Location, after: &Location) -> u32 {
     let time_offset = timestamp_ms - before.timestamp_ms;
     let time_difference = after.timestamp_ms - before.timestamp_ms;
 
@@ -144,7 +144,7 @@ fn interpolate_accuracy(timestamp_ms: i64, before: &Location, after: &Location) 
                 / time_difference
     };
 
-    accuracy as u16
+    accuracy as u32
 }
 
 #[derive(Clone, Deserialize, PartialEq, Debug)]
@@ -154,7 +154,7 @@ pub struct Location {
     timestamp_ms: i64,
     latitude_e7: i64,
     longitude_e7: i64,
-    accuracy: u16,
+    accuracy: u32,
 }
 
 impl Location {
@@ -165,7 +165,7 @@ impl Location {
         )
     }
 
-    pub fn accuracy(&self) -> u16 {
+    pub fn accuracy(&self) -> u32 {
         self.accuracy
     }
 

--- a/src/suggestion_accuracy.rs
+++ b/src/suggestion_accuracy.rs
@@ -4,16 +4,16 @@ use chrono::Duration;
 
 #[derive(Debug, PartialEq, Serialize)]
 pub struct SuggestionAccuracy {
-    meters: u16,
+    meters: u32,
     seconds: i64,
 }
 
 impl SuggestionAccuracy {
-    pub fn new(meters: u16, seconds: i64) -> SuggestionAccuracy {
+    pub fn new(meters: u32, seconds: i64) -> SuggestionAccuracy {
         SuggestionAccuracy { meters, seconds }
     }
 
-    pub fn meters(&self) -> u16 {
+    pub fn meters(&self) -> u32 {
         self.meters
     }
 


### PR DESCRIPTION
I faced a type issue. Based on my JSON from google takeout, accuracy goes over u16 such as "74130". And then, I got following error message from yore.

> thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: HistoryError(DeserializeError(ErrorImpl { code: Message("invalid value: integer `74130`, expected u16"), line: 277226, column: 22 }))', libcore/result.rs:945:5

So I simply increases the size.
